### PR TITLE
refactor/#12/providers-selection

### DIFF
--- a/openai-microservice/.env.example
+++ b/openai-microservice/.env.example
@@ -24,3 +24,14 @@ RABBITMQ_PASSWORD=
 OPENAI_KEY=
 OPENAI_ORGANIZATION=
 OPENAI_PROJECT=
+
+# Providers
+
+# "fakeAi" or "openAi"
+AI_PROVIDER=
+# "local" or "redis"
+CACHE_PROVIDER=
+# "rabbitmq"
+QUEUE_PROVIDER=
+# "socketio"
+SOCKET_PROVIDER=

--- a/openai-microservice/.env.test
+++ b/openai-microservice/.env.test
@@ -24,3 +24,9 @@ RABBITMQ_PASSWORD=fake_rabbit_password
 OPENAI_KEY=fake_openai_key
 OPENAI_ORGANIZATION=fake_openai_organization
 OPENAI_PROJECT=fake_openai_project
+
+# Providers
+AI_PROVIDER="fakeAi"
+CACHE_PROVIDER="local"
+QUEUE_PROVIDER="rabbitmq"
+SOCKET_PROVIDER="socketio"

--- a/openai-microservice/README.md
+++ b/openai-microservice/README.md
@@ -100,6 +100,12 @@ RABBITMQ_PASSWORD=
 OPENAI_KEY=
 OPENAI_ORGANIZATION=
 OPENAI_PROJECT=
+
+# Providers
+AI_PROVIDER=
+CACHE_PROVIDER=
+QUEUE_PROVIDER=
+SOCKET_PROVIDER=
 ```
 
 Define the user ID, email and password for login in TextMe. And define your OpenAI key. If you use the default created by the TextMe Server seed, you can use the credentials:

--- a/openai-microservice/README.md
+++ b/openai-microservice/README.md
@@ -73,7 +73,7 @@ npm i
 
 Create a `.env` file in root project. Fill all the keys of the content below with their respective values.
 
-```text
+```env
 # Environment
 NODE_ENV=development
 

--- a/openai-microservice/src/shared/container/providers/ai-provider/index.ts
+++ b/openai-microservice/src/shared/container/providers/ai-provider/index.ts
@@ -2,10 +2,14 @@ import { container } from 'tsyringe'
 import OpenAiProvider from './implementations/openai.provider'
 import FakeAiProvider from './implementations/fake-ai.provider'
 import { IAiProvider } from './types/iai-provider'
+import { env } from '@shared/resources/env'
 
 const implementations = {
   openAi: OpenAiProvider,
   fakeAi: FakeAiProvider,
 }
 
-container.registerSingleton<IAiProvider>('AiProvider', implementations.fakeAi)
+container.registerSingleton<IAiProvider>(
+  'AiProvider',
+  implementations[env.AI_PROVIDER],
+)

--- a/openai-microservice/src/shared/container/providers/cache-provider/index.ts
+++ b/openai-microservice/src/shared/container/providers/cache-provider/index.ts
@@ -2,6 +2,7 @@ import { container } from 'tsyringe'
 import LocalCacheProvider from './implementations/local-cache.provider'
 import { ICacheProvider } from './types/icache-provider'
 import RedisCacheProvider from './implementations/redis-cache.provider'
+import { env } from '@shared/resources/env'
 
 const implementations = {
   local: LocalCacheProvider,
@@ -10,5 +11,5 @@ const implementations = {
 
 container.registerSingleton<ICacheProvider>(
   'CacheProvider',
-  implementations.redis,
+  implementations[env.CACHE_PROVIDER],
 )

--- a/openai-microservice/src/shared/container/providers/queue-provider/index.ts
+++ b/openai-microservice/src/shared/container/providers/queue-provider/index.ts
@@ -1,6 +1,7 @@
 import { container } from 'tsyringe'
 import { RabbitMqQueueProvider } from './implementations/rabbitmq-queue.provider'
 import { IQueueProvider } from './types/iqueue.provider'
+import { env } from '@shared/resources/env'
 
 const implementations = {
   rabbitmq: RabbitMqQueueProvider,
@@ -8,5 +9,5 @@ const implementations = {
 
 container.registerSingleton<IQueueProvider>(
   'QueueProvider',
-  implementations.rabbitmq,
+  implementations[env.QUEUE_PROVIDER],
 )

--- a/openai-microservice/src/shared/container/providers/socket-client-provider/index.ts
+++ b/openai-microservice/src/shared/container/providers/socket-client-provider/index.ts
@@ -1,6 +1,7 @@
 import { container } from 'tsyringe'
 import { SocketIoClientProvider } from './implementations/socketio-client.provider'
 import { ISocketProvider } from './types/isocket-provider'
+import { env } from '@shared/resources/env'
 
 const implementations = {
   socketio: SocketIoClientProvider,
@@ -8,5 +9,5 @@ const implementations = {
 
 container.registerSingleton<ISocketProvider>(
   'SocketProvider',
-  implementations.socketio,
+  implementations[env.SOCKET_PROVIDER],
 )

--- a/openai-microservice/src/shared/resources/env/index.ts
+++ b/openai-microservice/src/shared/resources/env/index.ts
@@ -35,6 +35,12 @@ const envSchema = z.object({
   OPENAI_KEY: z.string(),
   OPENAI_ORGANIZATION: z.string(),
   OPENAI_PROJECT: z.string(),
+
+  // Providers
+  AI_PROVIDER: z.enum(['fakeAi', 'openAi']),
+  CACHE_PROVIDER: z.enum(['local', 'redis']),
+  QUEUE_PROVIDER: z.enum(['rabbitmq']),
+  SOCKET_PROVIDER: z.enum(['socketio']),
 })
 
 const _env = envSchema.safeParse(process.env)


### PR DESCRIPTION
Updates on OpenAI Microservice
- Providers selection now is made by env variables. So were added four more variables on env:

```env
# Providers

# "fakeAi" or "openAi"
AI_PROVIDER=
# "local" or "redis"
CACHE_PROVIDER=
# "rabbitmq"
QUEUE_PROVIDER=
# "socketio"
SOCKET_PROVIDER=
```